### PR TITLE
fix(template): wrong example database type

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ resources:
   replicas: 2
 
 dependencies:
-  - name: "postgres"
-    type: "database"
+  - name: "postgresql"
+    type: "postgresql"
     version: "15"
     storage: "1Gi"
 
@@ -483,8 +483,8 @@ Dependencies are automatically configured with connection strings and environmen
 ```yaml
 dependencies:
   # PostgreSQL database
-  - name: "postgres"  
-    type: "database"
+  - name: "postgresql"
+    type: "postgresql"
     version: "15"
     storage: "5Gi"
 
@@ -546,8 +546,8 @@ resources:
 
 # Dependencies (managed services)
 dependencies:
-  - name: "postgres"
-    type: "database"
+  - name: "postgresql"
+    type: "postgresql"
     version: "15"
     storage: "2Gi"
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -50,8 +50,8 @@ func initCmd() *cobra.Command {
 			// Dependencies
 			cfg.Dependencies = []config.Dependency{
 				{
-					Name:    "postgres",
-					Type:    "database",
+					Name:    "postgresql",
+					Type:    "postgresql",
 					Version: "15",
 					Storage: "1Gi",
 				},


### PR DESCRIPTION
Generated `deploayaja.yaml` file has wrong database type, fix it with correct type.

![Image](https://github.com/user-attachments/assets/99b8c5b0-671e-47be-ac92-3a4ddfdec2c0)