### PR TITLE
fix: error log stream

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -390,11 +390,9 @@ func (c *APIClient) GetLogsStream(name string, tail int, logChan chan<- LogEntry
 		// Parse SSE format: "data: {...}"
 		if strings.HasPrefix(line, "data: ") {
 			data := strings.TrimPrefix(line, "data: ")
+			data = strings.Trim(data, "\"")
 			if data == "[DONE]" {
-				// Stream ended
-				close(logChan)
-				close(errorChan)
-				return
+				continue
 			}
 
 			var logEntry LogEntry


### PR DESCRIPTION
There was an error while streaming logs due to an incorrect comparison between "[Done]" and [Done]
```
muhfaris@icehiro ~/D/p/s/s/g/m/mysql-deployaja> aja logs sadewa-94-app -f
📝 Fetching logs for sadewa-94-app...
🔄 Following logs (press Ctrl+C to stop)...
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.371829006Z /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, wi
ll attempt to perform configuration
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.371881357Z /docker-entrypoint.sh: Looking for shell scripts in /docker-e
ntrypoint.d/
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.374535087Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-list
en-on-ipv6-by-default.sh
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.394426437Z 10-listen-on-ipv6-by-default.sh: info: Getting the checksum o
f /etc/nginx/conf.d/default.conf
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.420885458Z 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6
 in /etc/nginx/conf.d/default.conf
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.420938988Z /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local
-resolvers.envsh
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.421216174Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envs
ubst-on-templates.sh
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.435051467Z /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune
-worker-processes.sh
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.438978239Z /docker-entrypoint.sh: Configuration complete; ready for star
t up
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461509603Z 2025/06/28 14:32:09 [notice] 1#1: using the "epoll" event met
hod
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461540021Z 2025/06/28 14:32:09 [notice] 1#1: nginx/1.29.0
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461553703Z 2025/06/28 14:32:09 [notice] 1#1: built by gcc 12.2.0 (Debian
 12.2.0-14+deb12u1)
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461676596Z 2025/06/28 14:32:09 [notice] 1#1: OS: Linux 6.8.0-62-generic
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461702271Z 2025/06/28 14:32:09 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1
048576:1048576
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.461724387Z 2025/06/28 14:32:09 [notice] 1#1: start worker processes
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.462011757Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 29
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.462304269Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 30
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.462671237Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 31
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.463918343Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 32
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.463932041Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 33
[2025-06-28 14:34:34] INFO 2025-06-28T14:32:09.463934456Z 2025/06/28 14:32:09 [notice] 1#1: start worker process 34
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850145426Z 2025/06/28 14:34:34 [notice] 1#1: signal 3 (SIGQUIT) received
, shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850210610Z 2025/06/28 14:34:34 [notice] 29#29: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850217677Z 2025/06/28 14:34:34 [notice] 33#33: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850221385Z 2025/06/28 14:34:34 [notice] 30#30: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850225860Z 2025/06/28 14:34:34 [notice] 31#31: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850231515Z 2025/06/28 14:34:34 [notice] 34#34: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850242000Z 2025/06/28 14:34:34 [notice] 33#33: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850251860Z 2025/06/28 14:34:34 [notice] 34#34: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850257527Z 2025/06/28 14:34:34 [notice] 29#29: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850262800Z 2025/06/28 14:34:34 [notice] 31#31: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850268275Z 2025/06/28 14:34:34 [notice] 32#32: gracefully shutting down
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850273577Z 2025/06/28 14:34:34 [notice] 34#34: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850279407Z 2025/06/28 14:34:34 [notice] 30#30: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850284707Z 2025/06/28 14:34:34 [notice] 29#29: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850289495Z 2025/06/28 14:34:34 [notice] 33#33: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850298978Z 2025/06/28 14:34:34 [notice] 31#31: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850312368Z 2025/06/28 14:34:34 [notice] 30#30: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850318025Z 2025/06/28 14:34:34 [notice] 32#32: exiting
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.850323398Z 2025/06/28 14:34:34 [notice] 32#32: exit
[2025-06-28 14:34:35] INFO 2025-06-28T14:34:34.864924386Z 2025/06/28 14:34:34 [notice] 1#1: signal 17 (SIGCHLD) receive
d from 32
Error: stream error: failed to parse log entry: json: cannot unmarshal string into Go value of type api.LogEntry
Usage:
  aja logs NAME [flags]

Flags:
  -f, --follow     Follow log output
  -h, --help       help for logs
      --tail int   Number of lines to show (default 100)

Error: stream error: failed to parse log entry: json: cannot unmarshal string into Go value of type api.LogEntry
```